### PR TITLE
Removed unnecessary statement

### DIFF
--- a/shower.js
+++ b/shower.js
@@ -439,8 +439,6 @@ window.shower = (function(window, document, undefined) {
 		if (typeof(callback) === 'function') {
 			callback();
 		}
-
-		return;
 	};
 
 	/**


### PR DESCRIPTION
Return is unnecessary as the last statment in a function with no return value.
