### PR TITLE
Enable zoom in/out

### DIFF
--- a/shower.js
+++ b/shower.js
@@ -307,15 +307,17 @@ window.shower = (function(window, document, undefined) {
 	* @returns {Boolean}
 	*/
 	shower._applyTransform = function(transform) {
-		[
-			'WebkitTransform',
-			'MozTransform',
-			'msTransform',
-			'OTransform',
-			'transform'
-		].forEach(function(prop) {
-				document.body.style[prop] = transform;
-		});
+		if ( ! (shower.isNonResizable)) {
+			[
+				'WebkitTransform',
+				'MozTransform',
+				'msTransform',
+				'OTransform',
+				'transform'
+			].forEach(function(prop) {
+					document.body.style[prop] = transform;
+			});
+		}
 
 		return true;
 	};
@@ -902,7 +904,7 @@ window.shower = (function(window, document, undefined) {
 	}, false);
 
 	window.addEventListener('resize', function() {
-		if (shower.isSlideMode() && ! (shower.isNonResizable)) {
+		if (shower.isSlideMode()) {
 			shower._applyTransform(shower._getTransform());
 		}
 	}, false);
@@ -999,6 +1001,9 @@ window.shower = (function(window, document, undefined) {
 
 			case 70: // F
 				shower.isNonResizable = ! (shower.isNonResizable);
+				if (shower.isSlideMode() && ! (shower.isNonResizable)) {
+					shower._applyTransform(shower._getTransform());
+				}
 			break;
 
 			default:

--- a/shower.js
+++ b/shower.js
@@ -20,6 +20,11 @@ window.shower = (function(window, document, undefined) {
 	shower.debugMode = false;
 
 	/**
+	* Automatic resizing disabled.
+	*/
+	shower.isNonResizable = false;
+
+	/**
 	 * Slide constructor
 	 *
 	 * @param {Object} opts
@@ -897,7 +902,7 @@ window.shower = (function(window, document, undefined) {
 	}, false);
 
 	window.addEventListener('resize', function() {
-		if (shower.isSlideMode()) {
+		if (shower.isSlideMode() && ! (shower.isNonResizable)) {
 			shower._applyTransform(shower._getTransform());
 		}
 	}, false);
@@ -990,6 +995,10 @@ window.shower = (function(window, document, undefined) {
 				if (e.altKey || e.ctrlKey || e.metaKey) { return; }
 				e.preventDefault();
 				shower[e.shiftKey ? '_turnPreviousSlide' : '_turnNextSlide']();
+			break;
+
+			case 70: // F
+				shower.isNonResizable = ! (shower.isNonResizable);
 			break;
 
 			default:


### PR DESCRIPTION
To improve a11y, users should be allowed to change the font size, like @tagawa [mentioned](https://github.com/shower/shower/issues/210).

This PR adds a key handler for `F` (&ldquo;freeze&rdquo;). Pressing that key toggles a new flag `isNonResizable`, which in turn prevents slides from rescaling automatically upon navigation and window resizing.

**To do:**
* [ ] Add tests
* [ ] Toggle scrolling too, eg change the property `overflow` of the `html` element, so that you can move around the slide when the font is so big that content doesn't fit in the screen any more
* [ ] Document this feature (where?)

**Open questions:**
* Shall we show on screen when this feature is enabled/disabled? For example, with a tiny icon in a corner
* Shall I commit here the updated uglified version, too?

Happy to have it merged as-is for now, and continue working on it. Equally happy if others want to help with the to-do above.

Fixes shower/shower#210.