### PR TITLE
Print in console only when debugMode is enabled

### DIFF
--- a/shower.js
+++ b/shower.js
@@ -792,7 +792,7 @@ window.shower = (function(window, document, undefined) {
 	* Clear presenter notes in console (only for Slide Mode).
 	*/
 	shower.clearPresenterNotes = function() {
-		if (shower.isSlideMode() && console && console.clear && ! shower.debugMode) {
+		if (shower.isSlideMode() && console && console.clear && shower.debugMode) {
 			console.clear();
 		}
 	};
@@ -804,7 +804,7 @@ window.shower = (function(window, document, undefined) {
 	shower.showPresenterNotes = function(slideNumber) {
 		shower.clearPresenterNotes();
 
-		if (console) {
+		if (console && shower.debugMode) {
 			slideNumber = shower._normalizeSlideNumber(slideNumber);
 
 			var slideId = shower.slideList[slideNumber].id,


### PR DESCRIPTION
I hate when in my console see something not mine.

I added in conditions (before run console.log/info) to check `debugMode`.
Otherwise i must edit vendor, ex. https://github.com/ksyrytczyk/presentation-warsawjs-es7/pull/1/files
this is awful solution, so I am recommend to add my changes to main lib.

I would like to hear your opinions.