### PR TITLE
Ignore hotkeys on input controls.

### DIFF
--- a/lib/shower/shower.Player.js
+++ b/lib/shower/shower.Player.js
@@ -186,7 +186,8 @@ shower.modules.define('shower.Player', [
         },
 
         _onKeyDown: function (e) {
-            if (!this._shower.isHotkeysEnabled()) {
+            if (!this._shower.isHotkeysEnabled() ||
+                /^(?:button|input|select|textarea)$/i.test(e.target.tagName)) {
                 return;
             }
 


### PR DESCRIPTION
Hotkeys would always be triggered, even if the user was typing something into a text field.
This commit ignores hotkeys if they are triggered on input controls.