### PR TITLE
Spacebar should scroll in list mode

### DIFF
--- a/lib/shower/shower.Player.js
+++ b/lib/shower/shower.Player.js
@@ -227,8 +227,9 @@ shower.modules.define('shower.Player', [
                     this.last();
                     break;
 
-                case 9: // Tab (Shift)
                 case 32: // Space (Shift)
+                    if (!this._shower.container.isSlideMode()) { return; }
+                case 9: // Tab (Shift)
                     if (e.altKey || e.ctrlKey || e.metaKey) { return; }
                     e.preventDefault();
 

--- a/tests/functional/keys.js
+++ b/tests/functional/keys.js
@@ -96,12 +96,30 @@ casper.test.begin(
 
 casper.test.begin(
 // ------------------------------------------------------------------
-    'Moving forward by Space', 1,
+    'Moving forward by Space in list mode', 1,
 // ------------------------------------------------------------------
     function suite(test) {
     casper.start('tests/functional/keys.html#1').then(function() {
 
         this.sendKeys('body', casper.page.event.key.Space);
+
+    }).then(function() {
+
+        test.assertExists('[id="1"].active', 'Current slide #1 is still active');
+
+    }).run(function() { test.done() }).clear();
+});
+
+casper.test.begin(
+// ------------------------------------------------------------------
+    'Moving forward by Space in slide mode', 1,
+// ------------------------------------------------------------------
+    function suite(test) {
+    casper.start('tests/functional/keys.html#1').then(function() {
+
+        this.sendKeys('body', casper.page.event.key.Enter);
+        this.sendKeys('body', casper.page.event.key.Space);
+        this.sendKeys('body', casper.page.event.key.Escape);
 
     }).then(function() {
 
@@ -224,12 +242,30 @@ casper.test.begin(
 
 casper.test.begin(
 // ------------------------------------------------------------------
-    'Moving backward by Shift Space', 1,
+    'Moving backward by Shift Space in list mode', 1,
 // ------------------------------------------------------------------
     function suite(test) {
     casper.start('tests/functional/keys.html#2').then(function() {
 
         this.sendKeys('body', casper.page.event.key.Space, { modifiers: 'shift' });
+
+    }).then(function() {
+
+        test.assertExists('[id="2"].active', 'Current slide #2 is still active');
+
+    }).run(function() { test.done() }).clear();
+});
+
+casper.test.begin(
+// ------------------------------------------------------------------
+    'Moving backward by Shift Space in slide mode', 1,
+// ------------------------------------------------------------------
+    function suite(test) {
+    casper.start('tests/functional/keys.html#2').then(function() {
+
+        this.sendKeys('body', casper.page.event.key.Enter);
+        this.sendKeys('body', casper.page.event.key.Space, { modifiers: 'shift' });
+        this.sendKeys('body', casper.page.event.key.Escape);
 
     }).then(function() {
 


### PR DESCRIPTION
I received a report (https://github.com/RubenVerborgh/WebFundamentals/issues/18) that **the current spacebar behavior in Shower is non-intuitive**.  As you know, the space bar on webpages typically has the function of scrolling.

In **slide mode**, it makes sense to change this behavior, since scrolling does not apply there. This is what Shower currently does.

In **list mode**, however, scrolling seems to the preferred behavior. Yet Shower alters this behavior to skipping to the next slide (for which there are many other keybindings anyway). **This commit fixes that behavior to scrolling in list mode.**

Should you have any concerns please let me know. In particular:
- I used a `case` fallthrough, which the style file allows me but you might not like.
- I was not sure if I needed to update the `keys.js` test (is it full screen or not?), as the tests on `master` currently don't run.