### PR TITLE
Remove dependencies between container and player

### DIFF
--- a/lib/shower/shower.Container.js
+++ b/lib/shower/shower.Container.js
@@ -211,8 +211,6 @@ shower.modules.define('shower.Container', [
                 case 116: // F5 (Shift)
                     e.preventDefault();
                     if (!this.isSlideMode()) {
-                        var slideNumber = e.shiftKey ? this._shower.player.getCurrentSlideIndex() : 0;
-                        this._shower.player.go(slideNumber);
                         this.enterSlideMode();
                     } else {
                         this.exitSlideMode();

--- a/lib/shower/shower.Player.js
+++ b/lib/shower/shower.Player.js
@@ -37,7 +37,7 @@ shower.modules.define('shower.Player', [
             this._showerListeners = this._shower.events.group()
                 .on('slideadd', this._onSlideAdd, this)
                 .on('slideremove', this._onSlideRemove, this)
-                .on('slidemodeenter', this._onContainerSlideModeEnter, this);
+                .on('slidemodeenter', this._onSlideModeEnter, this);
 
             this._playerListeners = this.events.group()
                 .on('prev', this._onPrev, this)
@@ -241,7 +241,7 @@ shower.modules.define('shower.Player', [
             }
         },
 
-        _onContainerSlideModeEnter: function () {
+        _onSlideModeEnter: function () {
             if (!this._currentSlide) {
                 this.go(0);
             }


### PR DESCRIPTION
`Container` and `Player` don't need to know about each other.