### PR TITLE
Add "main" section into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "presentation",
     "core"
   ],
+  "main": "shower.min.js",
   "files": [
     "shower.min.js",
     "LICENSE.md",


### PR DESCRIPTION
I've tried to use shower with webpack module builder and it can't import modules without `main` section in `package.json`