### PR TITLE
Issue #220: Set body role of application in slide mode

### DIFF
--- a/lib/shower/shower.Container.js
+++ b/lib/shower/shower.Container.js
@@ -77,6 +77,8 @@ shower.modules.define('shower.Container', [
             bodyClassList.remove(showerOptions.get('mode_list_classname'));
             bodyClassList.add(showerOptions.get('mode_full_classname'));
 
+            document.body.setAttribute("role", "application");
+
             this._applyTransform(this._getTransformScale());
 
             this._isSlideMode = true;
@@ -97,6 +99,8 @@ shower.modules.define('shower.Container', [
 
             elementClassList.remove(showerOptions.get('mode_full_classname'));
             elementClassList.add(showerOptions.get('mode_list_classname'));
+
+            document.body.removeAttribute("role", "application");
 
             this._applyTransform('none');
 

--- a/lib/shower/shower.Container.js
+++ b/lib/shower/shower.Container.js
@@ -77,7 +77,7 @@ shower.modules.define('shower.Container', [
             bodyClassList.remove(showerOptions.get('mode_list_classname'));
             bodyClassList.add(showerOptions.get('mode_full_classname'));
 
-            document.body.setAttribute("role", "application");
+            document.body.setAttribute('role', 'application');
 
             this._applyTransform(this._getTransformScale());
 
@@ -100,7 +100,7 @@ shower.modules.define('shower.Container', [
             elementClassList.remove(showerOptions.get('mode_full_classname'));
             elementClassList.add(showerOptions.get('mode_list_classname'));
 
-            document.body.removeAttribute("role", "application");
+            document.body.removeAttribute('role', 'application');
 
             this._applyTransform('none');
 


### PR DESCRIPTION
https://github.com/shower/shower/issues/220

Set the body role to "application" during slideshow mode (and remove it in gallery mode) Setting the application role supports slide show control when using a screenreader by passing keyboard control through to the application.