### PR TITLE
Update Travis config to specify GCC version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,12 @@ node_js:
   - "4.0"
   - "0.12"
   - '0.10.26'
+
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
I've noticed that the last build on Travis failed during `npm install` step: `wdio-allure-reporter` package depends on `fibers` which fails while trying to build itself.
Looks like this issue can be fixed by updating gcc version, so I added a few lines from Travis docs:
https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements

Tests will still fail, but at least for a different reason :)