### PR TITLE
Fix scrolling to slide after exiting fullscreen

### DIFF
--- a/lib/shower/container.js
+++ b/lib/shower/container.js
@@ -133,8 +133,9 @@ class Container {
      * @returns {Container}
      */
     scrollToCurrentSlide() {
+        const slidesSelector = this._shower.options.slides_selector;
         const activeSlideClass = this._shower.options.slide_active_classname;
-        const slideElement = this._element.querySelector(`.${activeSlideClass}`);
+        const slideElement = document.querySelector(`${slidesSelector}.${activeSlideClass}`);
         if (slideElement) {
             slideElement.scrollIntoView();
         }


### PR DESCRIPTION
Scrolling to the active slide after existing fullscreen in combination with the _next_ plugin has been broken for quite some time. The reason is that _next_ attaches the `.active` class to various elements, and that Shower is simply scrolling to the first `.active` element instead of to the first active slide (`.slide.active`). This pull request fixes this.

I've followed the spirit of the original code by using a CSS selector. However, I think that we should simplify this in the future: the Shower framework already knows the active slide, so we should just go to that element. Unfortunately, this is currently a protected field, so I did not use it. Perhaps this can be considered in the `merge-player-with-container` branch.