### PR TITLE
Adds basic screen reader support

### DIFF
--- a/lib/plugins/a11y.js
+++ b/lib/plugins/a11y.js
@@ -1,13 +1,118 @@
+import { isMac, isMetaEl, getFocusableElements } from '../utils';
+
 export default shower => {
     const liveRegion = document.createElement('section');
+
     liveRegion.className = 'region';
     liveRegion.setAttribute('role', 'region');
     liveRegion.setAttribute('aria-live', 'assertive');
-    liveRegion.setAttribute('aria-relevant', 'all');
-    liveRegion.setAttribute('aria-label', 'Slide Content: Auto-updating');
+
     document.body.appendChild(liveRegion);
 
-    const updateDocumentRole = () => {
+    /**
+     * Creates slide title.
+     *
+     * @param {Slide} slide
+     * @returns {string}
+     */
+    const getTitle = slide => {
+        if (!slide) return '';
+
+        const slideIndex = shower.getSlideIndex(slide);
+        const slideCount = shower.getSlidesCount();
+        const keyCommand = getKeyCommand();
+
+        return `${slide.getTitle() || ''} Slide ${slideIndex + 1} of ${slideCount}. ${keyCommand}`;
+    };
+
+    /**
+     * Generates a proper key command depending on:
+     *
+     *      - operating system (Cmd/Ctrl)
+     *      - slide/grid mode
+     *      - selected/not selected slide
+     *
+     * @todo i18n
+     * @returns {string}
+     */
+    const getKeyCommand = () => {
+        if (!shower.player.getCurrentSlide()) {
+            return 'Click arrow keys to select a slide.';
+        }
+
+        if (shower.container.isSlideMode()) {
+            return 'You are in the slide mode. Click Escape to exit.';
+        }
+
+        const shortcut = isMac() ? 'Command + Enter' : 'Shift + F5';
+
+        return `Click ${shortcut} to enter slide mode`;
+    };
+
+    /**
+     * Makes slide content accessible by AT.
+     *
+     * @param {HTMLElement} slideEl slide element
+     */
+    const showContent = slideEl => {
+        [].slice.call(slideEl.children).forEach(el => {
+            if (!isMetaEl(el)) {
+                el.removeAttribute('aria-hidden');
+            }
+        });
+    };
+
+    /**
+     * Hides slide content from AT.
+     *
+     * @param {HTMLElement} slideEl slide element
+     */
+    const hideContent = slideEl => {
+        [].slice.call(slideEl.children).forEach(el => {
+            if (!isMetaEl(el)) {
+                el.setAttribute('aria-hidden', true);
+            }
+        });
+    };
+
+    /**
+     * Keeps all interactive elements in a slide focusable.
+     *
+     * @param {HTMLElement} slideEl slide element
+     */
+    const allowFocus = slideEl => {
+        const focusable = getFocusableElements(slideEl);
+
+        [].slice.call(focusable).forEach(el => {
+            if (!isMetaEl(el)) {
+                el.removeAttribute('tabindex');
+            }
+        });
+    };
+
+    /**
+     * Makes all interactive elements in a slide unfocusable.
+     *
+     * @param {HTMLElement} slideEl slide element
+     */
+    const preventFocus = slideEl => {
+        const focusable = getFocusableElements(slideEl);
+
+        [].slice.call(focusable).forEach(el => {
+            if (!isMetaEl(el)) {
+                el.setAttribute('tabindex', -1);
+            }
+        });
+    };
+
+    const updateLiveRegion = () => {
+        const slide = shower.player.getCurrentSlide();
+        const title = getTitle(slide);
+
+        liveRegion.innerHTML = title;
+    };
+
+    const updateContainer = () => {
         if (shower.container.isSlideMode()) {
             document.body.setAttribute('role', 'application');
         } else {
@@ -15,16 +120,38 @@ export default shower => {
         }
     };
 
-    shower.container.events.on('modechange', updateDocumentRole);
-    updateDocumentRole();
+    const handleSlideContent = () => {
+        const slides = shower.getSlides();
 
-    const updateLiveRegion = () => {
-        const slide = shower.player.getCurrentSlide();
-        if (slide) {
-            liveRegion.innerHTML = slide.getContent();
-        }
+        slides.forEach(slide => {
+            const slideEl = slide.getElement();
+            const title = getTitle(slide);
+
+            slideEl.setAttribute('aria-label', title);
+
+            /**
+             * In a slide mode slides are fully accessible.
+             * In a grid mode only slide descriptions are accessible (plus slide's pesudo elements).
+             */
+            if (shower.container.isSlideMode()) {
+                showContent(slideEl);
+                allowFocus(slideEl);
+            } else {
+                hideContent(slideEl);
+                preventFocus(slideEl);
+            }
+        });
+    };
+
+    const handleModeChange = () => {
+        handleSlideContent();
+        updateContainer();
+        updateLiveRegion();
     };
 
     shower.player.events.on('activate', updateLiveRegion);
     updateLiveRegion();
+
+    shower.container.events.on('modechange', handleModeChange);
+    handleModeChange();
 };

--- a/lib/plugins/a11y.js
+++ b/lib/plugins/a11y.js
@@ -1,153 +1,41 @@
-import { isMac, isMetaEl, getFocusableElements } from '../utils';
-
 export default shower => {
     const liveRegion = document.createElement('section');
 
     liveRegion.className = 'region';
     liveRegion.setAttribute('role', 'region');
-    liveRegion.setAttribute('aria-live', 'assertive');
+    liveRegion.setAttribute('aria-live', 'polite');
 
     document.body.appendChild(liveRegion);
 
-    /**
-     * Creates slide title.
-     *
-     * @param {Slide} slide
-     * @returns {string}
-     */
-    const getTitle = slide => {
-        if (!slide) return '';
-
-        const slideIndex = shower.getSlideIndex(slide);
-        const slideCount = shower.getSlidesCount();
-        const keyCommand = getKeyCommand();
-
-        return `${slide.getTitle() || ''} Slide ${slideIndex + 1} of ${slideCount}. ${keyCommand}`;
-    };
-
-    /**
-     * Generates a proper key command depending on:
-     *
-     *      - operating system (Cmd/Ctrl)
-     *      - slide/grid mode
-     *      - selected/not selected slide
-     *
-     * @todo i18n
-     * @returns {string}
-     */
-    const getKeyCommand = () => {
-        if (!shower.player.getCurrentSlide()) {
-            return 'Click arrow keys to select a slide.';
-        }
-
-        if (shower.container.isSlideMode()) {
-            return 'You are in the slide mode. Click Escape to exit.';
-        }
-
-        const shortcut = isMac() ? 'Command + Enter' : 'Shift + F5';
-
-        return `Click ${shortcut} to enter slide mode`;
-    };
-
-    /**
-     * Makes slide content accessible by AT.
-     *
-     * @param {HTMLElement} slideEl slide element
-     */
-    const showContent = slideEl => {
-        [].slice.call(slideEl.children).forEach(el => {
-            if (!isMetaEl(el)) {
-                el.removeAttribute('aria-hidden');
-            }
-        });
-    };
-
-    /**
-     * Hides slide content from AT.
-     *
-     * @param {HTMLElement} slideEl slide element
-     */
-    const hideContent = slideEl => {
-        [].slice.call(slideEl.children).forEach(el => {
-            if (!isMetaEl(el)) {
-                el.setAttribute('aria-hidden', true);
-            }
-        });
-    };
-
-    /**
-     * Keeps all interactive elements in a slide focusable.
-     *
-     * @param {HTMLElement} slideEl slide element
-     */
-    const allowFocus = slideEl => {
-        const focusable = getFocusableElements(slideEl);
-
-        [].slice.call(focusable).forEach(el => {
-            if (!isMetaEl(el)) {
-                el.removeAttribute('tabindex');
-            }
-        });
-    };
-
-    /**
-     * Makes all interactive elements in a slide unfocusable.
-     *
-     * @param {HTMLElement} slideEl slide element
-     */
-    const preventFocus = slideEl => {
-        const focusable = getFocusableElements(slideEl);
-
-        [].slice.call(focusable).forEach(el => {
-            if (!isMetaEl(el)) {
-                el.setAttribute('tabindex', -1);
-            }
-        });
-    };
-
     const updateLiveRegion = () => {
-        const slide = shower.player.getCurrentSlide();
-        const title = getTitle(slide);
+        const container = shower.container.getElement();
+        const region = container.querySelector('.slide[role="region"]');
 
-        liveRegion.innerHTML = title;
-    };
-
-    const updateContainer = () => {
-        if (shower.container.isSlideMode()) {
-            document.body.setAttribute('role', 'application');
-        } else {
-            document.body.removeAttribute('role');
+        if (region) {
+            region.removeAttribute('role');
         }
-    };
 
-    const handleSlideContent = () => {
-        const slides = shower.getSlides();
+        const slide = shower.player.getCurrentSlide();
 
-        slides.forEach(slide => {
+        if (slide) {
             const slideEl = slide.getElement();
-            const title = getTitle(slide);
-
-            slideEl.setAttribute('aria-label', title);
-
-            /**
-             * In a slide mode slides are fully accessible.
-             * In a grid mode only slide descriptions are accessible (plus slide's pesudo elements).
-             */
-            if (shower.container.isSlideMode()) {
-                showContent(slideEl);
-                allowFocus(slideEl);
-            } else {
-                hideContent(slideEl);
-                preventFocus(slideEl);
-            }
-        });
+            slideEl.setAttribute('role', 'region');
+            slideEl.focus();
+        }
     };
 
     const handleModeChange = () => {
-        handleSlideContent();
-        updateContainer();
-        updateLiveRegion();
+        if (shower.container.isSlideMode()) {
+            liveRegion.textContent = 'You are in the slide mode';
+        } else {
+            liveRegion.textContent = 'You are in the list mode';
+        }
     };
+
+    shower.getSlides().forEach(slide => {
+        const slideEl = slide.getElement();
+        slideEl.setAttribute('tabindex', 0);
+    });
 
     shower.player.events.on('activate', updateLiveRegion);
     updateLiveRegion();

--- a/lib/plugins/keys.js
+++ b/lib/plugins/keys.js
@@ -5,7 +5,7 @@ export default shower => {
     const containerElement = container.getElement();
     containerElement.addEventListener('keydown', event => {
         if (event.defaultPrevented) return;
-        if (isInteractiveElement(event.target)) return;
+        if (isInteractiveElement(event.target) && !event.target.classList.contains('slide')) return;
 
         slideActions(event);
         modeActions(event);

--- a/lib/slide/index.js
+++ b/lib/slide/index.js
@@ -121,12 +121,12 @@ class Slide {
     }
 
     /**
-     * Get slide content.
+     * Get slide HTML element.
      *
-     * @borrows Layout.getContent
+     * @borrows Layout.getElement
      */
-    getContent() {
-        return this.layout.getContent();
+    getElement() {
+        return this.layout.getElement();
     }
 
     _setupListeners() {

--- a/lib/slide/layout.js
+++ b/lib/slide/layout.js
@@ -124,16 +124,7 @@ class Layout {
         const titleSelector = this.options.title_element_selector;
         const titleElement = this._element.querySelector(titleSelector);
 
-        return titleElement && titleElement.textContent;
-    }
-
-    /**
-     * Get inner content from slide element.
-     *
-     * @returns {string} Slide content.
-     */
-    getContent() {
-        return this._element.innerHTML;
+        return titleElement && titleElement.textContent.trim();
     }
 
     _setupListeners() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,2 +1,8 @@
+const META_EL_TAGS = ['link', 'meta', 'base', 'script', 'style', 'title'];
+const FOCUSABLE_EL_SELECTOR = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+
 export const isInteractiveElement = element => element.tabIndex !== -1;
 export const isModifierUsed = event => event.ctrlKey || event.altKey || event.metaKey;
+export const isMac = () => /Mac/.test(window.navigator.platform);
+export const isMetaEl = el => META_EL_TAGS.find(tag => tag === el.tagName.toLowerCase());
+export const getFocusableElements = el => el.querySelectorAll(FOCUSABLE_EL_SELECTOR);


### PR DESCRIPTION
## Basic screen reader support

This PR is a first step to a11y enhancement.

**ADD FOLLOWING STYLES IN `<head>` (from PRs https://github.com/shower/ribbon/pull/52 and https://github.com/shower/ribbon/pull/54):**

```css
.shower.full .slide {
    visibility: hidden;
}

.shower.full .slide.active {
    visibility: visible;
}

.shower.list .region {
    display: inherit;
}

.shower.full .region {
    display: inherit;
}
```

### Done
- navigation in *grid mode*
  - only slide titles pronounced
- navigation in *slide mode*
  - all slide content pronounced
- updated `region` content
  - hints for `shower` shortcuts added

### Todo
- update `region` when `.next` element appears
- test in NVDA and JAWS
- add tests