### PR TITLE
Also include source files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "main": "lib/shower.js",
   "files": [
+    "lib",
     "dist/shower.js"
   ],
   "devDependencies": {


### PR DESCRIPTION
That way, external users can `import Shower from '@shower/core'` and build upon it.