### PR TITLE
API change: use singular nouns preceding "count"

### DIFF
--- a/lib/modules/next.js
+++ b/lib/modules/next.js
@@ -23,7 +23,7 @@ export default (shower) => {
 
         const slide = shower.activeSlide;
         if (slide) {
-            slide.state.innerStepsCount = innerSteps.length;
+            slide.state.innerStepCount = innerSteps.length;
         }
     };
 

--- a/lib/modules/timer/index.js
+++ b/lib/modules/timer/index.js
@@ -8,14 +8,14 @@ export default (shower) => {
         if (shower.isListMode) return;
 
         const slide = shower.activeSlide;
-        const { visitsCount, innerStepsCount } = slide.state;
-        if (visitsCount > 1) return;
+        const { visitCount, innerStepCount } = slide.state;
+        if (visitCount > 1) return;
 
         const timing = parseTiming(slide.element.dataset.timing);
         if (!timing) return;
 
-        if (innerStepsCount) {
-            const stepTiming = timing / (innerStepsCount + 1);
+        if (innerStepCount) {
+            const stepTiming = timing / (innerStepCount + 1);
             id = setInterval(() => shower.next(), stepTiming);
         } else {
             id = setTimeout(() => shower.next(), timing);

--- a/lib/slide.js
+++ b/lib/slide.js
@@ -18,8 +18,8 @@ class Slide extends EventTarget {
 
         this._isActive = false;
         this.state = {
-            visitsCount: 0,
-            innerStepsCount: 0,
+            visitCount: 0,
+            innerStepCount: 0,
         };
     }
 
@@ -28,7 +28,7 @@ class Slide extends EventTarget {
     }
 
     get isVisited() {
-        return this.state.visitsCount > 0;
+        return this.state.visitCount > 0;
     }
 
     get id() {
@@ -43,7 +43,7 @@ class Slide extends EventTarget {
     activate() {
         if (this._isActive) return;
 
-        this.state.visitsCount++;
+        this.state.visitCount++;
         this.element.classList.add(this.options.activeSlideClass);
 
         this._isActive = true;


### PR DESCRIPTION
[English Language & Usage Stack Exchange](https://english.stackexchange.com):
* [Singular or plural noun preceding “count”](https://english.stackexchange.com/questions/349475/singular-or-plural-noun-preceding-count).
* [How to write correctly chains of nouns with plurals like “Messages List” and “Apple Count” for IT](https://english.stackexchange.com/questions/229406/how-to-write-correctly-chains-of-nouns-with-plurals-like-messages-list-and-ap).