### PR TITLE
Prevent instance properties from being reassigned

### DIFF
--- a/lib/shower.js
+++ b/lib/shower.js
@@ -19,6 +19,7 @@ class Shower extends EventTarget {
 
         this._mode = 'list';
         this._isStarted = false;
+        this._container = null;
     }
 
     /**
@@ -32,8 +33,8 @@ class Shower extends EventTarget {
         if (this._isStarted) return;
 
         const { containerSelector } = this.options;
-        this.container = document.querySelector(containerSelector);
-        if (!this.container) {
+        this._container = document.querySelector(containerSelector);
+        if (!this._container) {
             throw new Error(`Shower container with selector '${containerSelector}' not found.`);
         }
 
@@ -46,7 +47,7 @@ class Shower extends EventTarget {
 
     _initSlides() {
         const slideElements = [
-            ...this.container.querySelectorAll(this.options.slideSelector),
+            ...this._container.querySelectorAll(this.options.slideSelector),
         ].filter((slideElement) => !slideElement.hidden);
 
         slideElements.forEach(ensureSlideId);
@@ -90,6 +91,10 @@ class Shower extends EventTarget {
         });
 
         this.dispatchEvent(event);
+    }
+
+    get container() {
+        return this._container;
     }
 
     get isFullMode() {

--- a/lib/shower.js
+++ b/lib/shower.js
@@ -1,6 +1,6 @@
 import defaultOptions from './default-options';
 import Slide from './slide';
-import { EventTarget } from './utils';
+import { EventTarget, defineReadOnly } from './utils';
 import installModules from './modules';
 
 const ensureSlideId = (slideElement, index) => {
@@ -13,9 +13,12 @@ class Shower extends EventTarget {
     constructor(options) {
         super();
 
+        defineReadOnly(this, {
+            options: { ...defaultOptions, ...options },
+        });
+
         this._mode = 'list';
         this._isStarted = false;
-        this.options = { ...defaultOptions, ...options };
     }
 
     /**

--- a/lib/slide.js
+++ b/lib/slide.js
@@ -1,4 +1,4 @@
-import { EventTarget } from './utils';
+import { EventTarget, defineReadOnly } from './utils';
 
 /**
  * @param {HTMLElement} element
@@ -8,19 +8,20 @@ class Slide extends EventTarget {
     constructor(element, options) {
         super();
 
-        this.element = element;
-        this.options = options;
+        defineReadOnly(this, {
+            element,
+            options,
+            state: {
+                visitCount: 0,
+                innerStepCount: 0,
+            },
+        });
 
+        this._isActive = false;
         this.element.addEventListener('click', () => {
             this.activate();
             this.dispatchEvent(new Event('fullmoderequest'));
         });
-
-        this._isActive = false;
-        this.state = {
-            visitCount: 0,
-            innerStepCount: 0,
-        };
     }
 
     get isActive() {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -8,3 +8,14 @@ export const contentLoaded = (callback) => {
         document.addEventListener('DOMContentLoaded', callback);
     }
 };
+
+export const defineReadOnly = (target, props) => {
+    for (const [key, value] of Object.entries(props)) {
+        Object.defineProperty(target, key, {
+            value,
+            writable: false,
+            enumerable: true,
+            configurable: true,
+        });
+    }
+};


### PR DESCRIPTION
Given that we don't handle reassignments of `shower.container` and `slide.element`, users may end up with weird behaviour because of a third-party plugin.

This change brings some integrity by silently suppressing reassignments (or throwing `TypeError` in strict mode) and enforces reference equality between `shower.options` and `slide.options`.