### PR TITLE
Add hide mouse class to the container if inactive

### DIFF
--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -4,7 +4,7 @@ export default {
     stepSelector: '.next',
     fullModeClass: 'full',
     listModeClass: 'list',
-    mouseHiddenClass: 'mouse-hidden',
+    mouseHiddenClass: 'pointless',
     mouseInactivityTimeout: 5000,
 
     slideSelector: '.slide',

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -4,6 +4,8 @@ export default {
     stepSelector: '.next',
     fullModeClass: 'full',
     listModeClass: 'list',
+    mouseHiddenClass: 'mouse-hidden',
+    mouseInactivityTimeout: 5000,
 
     slideSelector: '.slide',
     slideTitleSelector: 'h2',

--- a/lib/modules/install.js
+++ b/lib/modules/install.js
@@ -7,6 +7,7 @@ import timer from './timer';
 import title from './title';
 import view from './view';
 import touch from './touch';
+import mouse from './mouse';
 
 export default (shower) => {
     a11y(shower);
@@ -18,6 +19,7 @@ export default (shower) => {
     location(shower); // should come after `title`
     view(shower);
     touch(shower);
+    mouse(shower);
 
     // maintains invariant: active slide always exists in `full` mode
     if (shower.isFullMode && !shower.activeSlide) {

--- a/lib/modules/mouse.js
+++ b/lib/modules/mouse.js
@@ -31,6 +31,6 @@ export default (shower) => {
         }
     };
 
-    shower.on('start', handleModeChange);
-    shower.on('modechange', handleModeChange);
+    shower.addEventListener('start', handleModeChange);
+    shower.addEventListener('modechange', handleModeChange);
 };

--- a/lib/modules/mouse.js
+++ b/lib/modules/mouse.js
@@ -1,0 +1,36 @@
+export default (shower) => {
+    const { mouseHiddenClass, mouseInactivityTimeout } = shower.options;
+
+    let hideMouseTimeoutId = null;
+
+    const cleanUp = () => {
+        shower.container.classList.remove(mouseHiddenClass);
+        clearTimeout(hideMouseTimeoutId);
+        hideMouseTimeoutId = null;
+    };
+
+    const hideMouseIfInactive = () => {
+        if (hideMouseTimeoutId !== null) {
+            cleanUp();
+        }
+
+        hideMouseTimeoutId = setTimeout(() => {
+            shower.container.classList.add(mouseHiddenClass);
+        }, mouseInactivityTimeout);
+    };
+
+    const initHideMouseIfInactiveModule = () => {
+        shower.container.addEventListener('mousemove', hideMouseIfInactive);
+    };
+
+    const handleModeChange = () => {
+        if (shower.isFullMode) {
+            initHideMouseIfInactiveModule();
+        } else {
+            cleanUp();
+        }
+    };
+
+    shower.on('start', handleModeChange);
+    shower.on('modechange', handleModeChange);
+};

--- a/lib/modules/mouse.js
+++ b/lib/modules/mouse.js
@@ -23,11 +23,16 @@ export default (shower) => {
         shower.container.addEventListener('mousemove', hideMouseIfInactive);
     };
 
+    const destroyHideMouseIfInactiveModule = () => {
+        shower.container.removeEventListener('mousemove', hideMouseIfInactive);
+        cleanUp();
+    };
+
     const handleModeChange = () => {
         if (shower.isFullMode) {
             initHideMouseIfInactiveModule();
         } else {
-            cleanUp();
+            destroyHideMouseIfInactiveModule();
         }
     };
 


### PR DESCRIPTION
Current PR add mouse module to shower.

Only for full mode:

If mouse is not moved for timeout (default 5000ms) then `mouse-hidden` (configurable in options) class is added to the shower container.
And on every mouse move timer is reset and this class is being removed.

Fixes https://github.com/shower/shower/issues/377

